### PR TITLE
Added HomeAssistant service to ask OpenMindsAI

### DIFF
--- a/custom_components/openmindsai/__init__.py
+++ b/custom_components/openmindsai/__init__.py
@@ -1,1 +1,55 @@
+import requests
 """OpenMindsAI custom component."""
+
+DOMAIN = "openmindsai"
+
+ATTR_NAME = "prompt"
+MODEL_NAME = "model"
+SESSION_COOKIE_NAME = "session"
+DEFAULT_PROMPT = "Give an example prompt for ChatGPT"
+DEFAULT_MODEL = "gpt4hassio"
+DEFAULT_SESSION_COOKIE = "gpt4hassio"
+
+
+def setup(hass, config):
+
+    """Set up is called when Home Assistant is loading our component."""
+
+    def ask(call):
+        """Handle the service call."""
+        prompt = call.data.get(ATTR_NAME, DEFAULT_PROMPT)
+        model = call.data.get(MODEL_NAME, DEFAULT_MODEL)
+        session_cookie = call.data.get(SESSION_COOKIE_NAME, DEFAULT_SESSION_COOKIE)
+        
+
+        hass.states.set("openmindsai.response", "querying", {
+            "response" : ""
+        })
+
+        ask_to_ia(session_cookie, model, prompt)
+
+        return True
+        
+    def query_message(query, token_budget=4096 - 500):
+        return query
+
+    def ask_to_ia(session_cookie, model, query, token_budget=4096 - 500):
+        message = query_message(query, token_budget=token_budget)
+    
+        url = f"https://cloud.mindsdb.com/api/projects/mindsdb/models/{model}/predict"
+        cookies = {"session": session_cookie}
+        data = {"data": [{"text": message}]}
+        headers = {"Content-Type": "application/json"}
+    
+        response = requests.post(url, json=data, cookies=cookies, headers=headers)
+        response_json = response.json()
+        response_message = response_json[0]["response"]
+    
+        hass.states.set("openmindsai.response", "done", {
+            "response" : response_message
+        })
+
+    hass.services.register(DOMAIN, "ask", ask)
+
+    # Return boolean to indicate that initialization was successful.
+    return True


### PR DESCRIPTION
Hi, I've added a service to this custom-integration since I wanted to use the feature in automations and managing large inputs. (input_text) only have 255 characters. 

You can use as follows:

```yaml
    service: openmindsai.ask
    data:
      prompt: 'Generate a morning report with the following inputs: Temperature: 21 ºC, Events: Medical appointment at 10 AM'
      session: .eJw9i0kKgDA.......
```

This way, you can create scripts or automations like the following:

```yaml
ia_to_alexa:
  alias: ia_to_alexa
  fields:
    prompt:
      description: The text you would like to ask the IA.
      example: Tell me a joke
    alexa_devices:
      description: Alexa devices you want to trigger
      example: media_player.bedroom_echo
    broadcast:
      description: If you want to broadcast the response for all the echo devices.
        If this option is enabled, the alexa_devices field will be ignored
      example: true
  sequence:
  - service: openmindsai.ask
    data:
      prompt: '{{ prompt }}'
      session: .eJw9i0kKgDA.......
  - if:
    - condition: template
      value_template: '{{broadcast}}'
    then:
    - service: script.notfy_with_alexa
      data:
        message: '{{state_attr(''openmindsai.response'',''response'')}}'
    - service: telegram_bot.send_message
      data:
        message: '{{state_attr(''openmindsai.response'',''response'')}}'
    else:
    - service: notify.alexa_media
      data:
        target: "{% for e in alexa_devices %}\n  {% if loop.first %}{% else %}, {%
          endif %}\n{{ e }} {% endfor %}\n"
        message: '{{state_attr(''openmindsai.response'',''response'')}}'
  mode: single
```


Feel free to discard this PR if you don't wat to include this feature.